### PR TITLE
Add support for Uptime Kuma push monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mount your backup directory as `/var/backups` (or override `$BACKUP_DIR`). Backu
 
 Backups run daily at midnight. To change this, add a cron-style schedule to `$SCHEDULE`. For more information on the format of the cron strings, please see the [croniter documentation on PyPI](https://pypi.org/project/croniter/).
 
-Additionally, there is support for [healthchecks.io](https://healthchecks.io). `$HEALTHCHECKS_ID` can be used to specify the id to ping. If you're using a self-hosted instance, set `$HEALTHCHECKS_HOST`.
+Additionally, there is support for [healthchecks.io](https://healthchecks.io) and [Uptime Kuma](https://github.com/louislam/uptime-kuma/) for monitoring purposes. `$HEALTHCHECKS_ID` can be used to specify the id to ping. If you're using a self-hosted instance, set `$HEALTHCHECKS_HOST`. To use the generated URL by the Monitor Type `Push` in Uptime Kuma, set `$UPTIME_KUMA_URL`.
 
 Files are backed up uncompressed by default, on the assumption a snapshotting or native compressed filesystem is being used (eg ZFS). To enable compression, set `$COMPRESSION` to one of the supported algorithms:
 

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -195,7 +195,7 @@ def backup(now: datetime) -> None:
         ).raise_for_status()
 
     if uptime_kuma_url := os.environ.get("UPTIME_KUMA_URL"):
-        requests.get(uptime_kuma_url)      
+        requests.get(uptime_kuma_url).raise_for_status()      
 
 
 if __name__ == "__main__":

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -195,7 +195,7 @@ def backup(now: datetime) -> None:
         ).raise_for_status()
 
     if uptime_kuma_url := os.environ.get("UPTIME_KUMA_URL"):
-        requests.get(uptime_kuma_url).raise_for_status()      
+        requests.get(uptime_kuma_url).raise_for_status()
 
 
 if __name__ == "__main__":

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -194,6 +194,9 @@ def backup(now: datetime) -> None:
             data="\n".join(backed_up_containers),
         ).raise_for_status()
 
+    if uptime_kuma_url := os.environ.get("UPTIME_KUMA_URL"):
+        requests.get(uptime_kuma_url)      
+
 
 if __name__ == "__main__":
     if os.environ.get("SCHEDULE"):


### PR DESCRIPTION
- Purpose: enables the use of [Uptime Kuma](https://github.com/louislam/uptime-kuma) as monitoring service
- Changes: adds `UPTIME_KUMA_URL` environment variable
- Context: 
  - after creating a push monitor in Uptime Kuma, a URL is generated with the following format: `https://uptimekuma.example.com/api/push/XXXXXXXXXX?status=up&msg=OK&ping=`
  - https://github.com/louislam/uptime-kuma/issues/279