### PR TITLE
Add support for pgvector container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A script to automatically back up all databases running under docker on a host, 
 ## Supported databases
 
 - MySQL (including MariaDB and LSIO's MariaDB)
-- PostgreSQL (including [TimescaleDB](https://www.timescale.com/), [pgvecto.rs](https://github.com/tensorchord/pgvecto.rs), and Nextcloud's [AIO](https://github.com/nextcloud/all-in-one))
+- PostgreSQL (including [TimescaleDB](https://www.timescale.com/), [pgvecto.rs](https://github.com/tensorchord/pgvecto.rs), [pgvector](https://github.com/pgvector/pgvector), and Nextcloud's [AIO](https://github.com/nextcloud/all-in-one))
 - Redis
 
 ## Installation

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -135,6 +135,7 @@ BACKUP_PROVIDERS: list[BackupProvider] = [
             "tensorchord/pgvecto-rs",
             "nextcloud/aio-postgresql",
             "timescale/timescaledb",
+            "pgvector/pgvector",
         ],
         backup_method=backup_psql,
         file_extension="sql",


### PR DESCRIPTION
Support backups for https://github.com/pgvector/pgvector
The container base image is `postgres`