### PR TITLE
feat: add docker label selection

### DIFF
--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -162,6 +162,7 @@ SCHEDULE = os.environ.get("SCHEDULE", "0 0 * * *")
 SHOW_PROGRESS = sys.stdout.isatty()
 COMPRESSION = os.environ.get("COMPRESSION", "plain")
 INCLUDE_LOGS = bool(os.environ.get("INCLUDE_LOGS"))
+AUTO_BACKUP_LABEL = os.environ.get("AUTO_BACKUP_LABEL", "auto-backup")
 
 
 def get_backup_provider(container_names: Iterable[str]) -> Optional[BackupProvider]:
@@ -199,8 +200,16 @@ def backup(now: datetime) -> None:
     print(f"Found {len(containers)} containers.")
 
     for container in containers:
-        container_names = get_container_names(container)
-        backup_provider = get_backup_provider(container_names)
+        if auto_backup_label := container.labels.get(AUTO_BACKUP_LABEL):
+            if auto_backup_label.lower() == "false":
+                print(f"Skipping {container.name} because label {AUTO_BACKUP_LABEL}=false")
+                continue
+            print(f"Found explicit {AUTO_BACKUP_LABEL} label for {container.name}, using {auto_backup_label}")
+            backup_provider = get_backup_provider([auto_backup_label])
+        else:
+            container_names = get_container_names(container)
+            backup_provider = get_backup_provider(container_names)
+
         if backup_provider is None:
             continue
 


### PR DESCRIPTION
Allows any compatible databases to be backed up using container labels.

e.g. we can now backup valkey since it's redis compatible:

```yaml
services:
  valkey:
    image: valkey/valkey:9
    labels:
      - "auto-backup=redis"
```

or backup custom images:

```yaml
services:
  my_custom_database:
    image: some.private.host/organization/custom_database:latest
    labels:
      - "auto-backup=postgres"
```

or skip a non-essential datbase from backups:

```yaml
services:
  unimportant:
    image: postgres:18
    labels:
      - "auto-backup=false"
```