### PR TITLE
fix: detect images pulled by digest (no RepoTags) (#101)

### DIFF
--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -175,17 +175,52 @@ def get_backup_provider(container_names: Iterable[str]) -> Optional[BackupProvid
     return None
 
 
+def _name_from_image_reference(reference: str) -> Optional[str]:
+    """
+    Extract the image name from a tag or digest reference.
+
+    Handles three forms:
+      - ``name:tag``            (e.g. ``postgres:14-alpine``)
+      - ``name@digest``         (e.g. ``ghcr.io/immich-app/postgres@sha256:abc...``)
+      - ``registry/name:tag@digest`` (e.g. ``docker.io/library/postgres:14@sha256:abc...``)
+    """
+    # Strip the digest suffix if present (e.g. @sha256:...).
+    # We only care about the name part for matching against patterns.
+    image_ref = reference.split("@", 1)[0]
+    if not image_ref:
+        return None
+
+    registry, image = docker.auth.resolve_repository_name(image_ref)
+
+    # HACK: Strip "library" from official images
+    if registry == docker.auth.INDEX_NAME:
+        image = image.removeprefix("library/")
+
+    # Tags may be absent when the image was referenced only by digest, so
+    # `:` may not appear. In that case, the whole string is the name.
+    if ":" in image:
+        image, _ = image.split(":", 1)
+
+    return image
+
+
 def get_container_names(container: Container) -> Iterable[str]:
-    names = set()
-    for tag in container.image.tags:
-        registry, image = docker.auth.resolve_repository_name(tag)
+    names: set[str] = set()
 
-        # HACK: Strip "library" from official images
-        if registry == docker.auth.INDEX_NAME:
-            image = image.removeprefix("library/")
+    # Prefer `RepoTags` for the common case. When the image was pulled by
+    # digest, this is empty and we fall back to the original image reference
+    # stored on the container's config, which preserves the digest form.
+    references: list[str] = list(container.image.tags)
+    if not references:
+        config_image = (container.attrs.get("Config") or {}).get("Image")
+        if config_image:
+            references.append(config_image)
 
-        image, tag_name = image.split(":", 1)
-        names.add(image)
+    for reference in references:
+        name = _name_from_image_reference(reference)
+        if name:
+            names.add(name)
+
     return names
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -135,3 +135,72 @@ def test_get_backup_provider(container_name: str, name: str) -> None:
 
     assert provider is not None
     assert provider.name == name
+
+
+@pytest.mark.parametrize(
+    "reference,name",
+    [
+        (
+            "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:"
+            "32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a",
+            "immich-app/postgres",
+        ),
+        (
+            "postgres@sha256:32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a",
+            "postgres",
+        ),
+        (
+            "docker.io/library/postgres@sha256:32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a",
+            "postgres",
+        ),
+        (
+            "ghcr.io/realorangeone/db-auto-backup@sha256:32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a",
+            "realorangeone/db-auto-backup",
+        ),
+    ],
+)
+def test_name_from_image_reference_with_digest(reference: str, name: str) -> None:
+    assert db_auto_backup._name_from_image_reference(reference) == name
+
+
+@pytest.mark.parametrize(
+    "reference,name",
+    [
+        ("postgres:14-alpine", "postgres"),
+        ("ghcr.io/realorangeone/db-auto-backup:latest", "realorangeone/db-auto-backup"),
+        ("postgres", "postgres"),
+        ("ghcr.io/immich-app/postgres", "immich-app/postgres"),
+    ],
+)
+def test_name_from_image_reference_without_digest(reference: str, name: str) -> None:
+    assert db_auto_backup._name_from_image_reference(reference) == name
+
+
+def test_get_container_names_falls_back_to_config_image() -> None:
+    """
+    Images pulled by digest (e.g. `image@sha256:...`) have an empty
+    `RepoTags` list. `get_container_names` should fall back to the
+    container's `Config.Image` so the container is still detected.
+    """
+    container = MagicMock()
+    container.image.tags = []
+    container.attrs = {
+        "Config": {
+            "Image": (
+                "ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"
+                "@sha256:32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a"
+            )
+        }
+    }
+    assert db_auto_backup.get_container_names(container) == {"immich-app/postgres"}
+
+
+def test_get_container_names_empty_when_no_reference() -> None:
+    """
+    When both `RepoTags` and `Config.Image` are missing or empty, the
+    container should simply produce no names (not crash).
+    """
+    container = MagicMock()
+    container.image.tags = []
+    container.attrs = {"Config": {}}
+    assert db_auto_backup.get_container_names(container) == set()


### PR DESCRIPTION
Fixes #101

When a container's image was pulled by digest (e.g. via `image@sha256:...` in a compose file), Docker does not assign any `RepoTags`, so `container.image.tags` is an empty list and the container was silently skipped during backup.

This was particularly painful for Immich, whose compose file pins the postgres image by digest, e.g.:

```
ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:32324a2f41df5de9efe1af166b7008c3f55646f8d0e00d9550c16c9822366b4a
```

**Before:** `get_container_names` would return an empty set, `immich-app/postgres` never matched a backup pattern, and the database was silently skipped.

**After:** `get_container_names` falls back to `container.attrs['Config']['Image']` (which preserves the original digest reference) and the new `_name_from_image_reference` helper correctly strips the `@sha256:...` digest suffix before matching.

## Changes

- **`db-auto-backup.py`**:
  - New `_name_from_image_reference(reference)` helper that handles `name:tag`, `name@digest`, and `registry/name:tag@digest` forms.
  - `get_container_names` now also reads `Config.Image` as a fallback when `RepoTags` is empty, and uses the new helper.
  - The old `image.split(":", 1)` crash when no tag separator is present is gone — the helper tolerates tags being absent (digest-only references).

- **`tests/tests.py`**:
  - `test_name_from_image_reference_with_digest` — 4 parametrized cases covering Immich-style, official-library, and pure-digest references.
  - `test_name_from_image_reference_without_digest` — 4 cases for the existing `name:tag` form (including tag-less images).
  - `test_get_container_names_falls_back_to_config_image` — end-to-end check that the digest-pinned Immich image is now detected.
  - `test_get_container_names_empty_when_no_reference` — confirms we degrade gracefully when both `RepoTags` and `Config.Image` are missing.

## Test run

```
python3 -m pytest tests/tests.py --deselect tests/tests.py::test_backup_runs --deselect tests/tests.py::test_backup_runs_compressed
================= 37 passed, 6 deselected, 1 warning in 0.20s ==================
```

(Integration tests `test_backup_runs` / `test_backup_runs_compressed` were skipped because they require a live Docker test container from `tests/conftest.py`; they are unchanged.)

`black`, `ruff`, and `mypy` all pass clean.

— Sent via @AmSach bot
