### PR TITLE
Add support for images pulled via digest

### DIFF
--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -193,6 +193,7 @@ def get_container_names(container: Container) -> Iterable[str]:
 
     return names
 
+
 def resolve_image(tag: str) -> str:
     """
     Resolve an image tag to its canonical name.
@@ -212,6 +213,7 @@ def resolve_image(tag: str) -> str:
 
     image_only = image.split(":", 1)[0]
     return image_only
+
 
 @pycron.cron(SCHEDULE)
 def backup(now: datetime) -> None:

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -134,6 +134,7 @@ BACKUP_PROVIDERS: list[BackupProvider] = [
             "postgres",
             "tensorchord/pgvecto-rs",
             "nextcloud/aio-postgresql",
+            "nextloud-releases/aio-postgresql",
             "timescale/timescaledb",
             "pgvector/pgvector",
             "pgautoupgrade/pgautoupgrade",

--- a/db-auto-backup.py
+++ b/db-auto-backup.py
@@ -180,16 +180,37 @@ def get_backup_provider(container_names: Iterable[str]) -> Optional[BackupProvid
 def get_container_names(container: Container) -> Iterable[str]:
     names = set()
     for tag in container.image.tags:
-        registry, image = docker.auth.resolve_repository_name(tag)
-
-        # HACK: Strip "library" from official images
-        if registry == docker.auth.INDEX_NAME:
-            image = image.removeprefix("library/")
-
-        image, tag_name = image.split(":", 1)
+        image = resolve_image(tag)
         names.add(image)
+
+    # Fallback in case image was pulled via digest instead of tag
+    if not names:
+        image_field = container.attrs.get("Config", {}).get("Image")
+        if image_field:
+            image = resolve_image(image_field)
+            names.add(image)
+
     return names
 
+def resolve_image(tag: str) -> str:
+    """
+    Resolve an image tag to its canonical name.
+
+    For example, "postgres:latest" becomes "postgres".
+    """
+    try:
+        registry, image = docker.auth.resolve_repository_name(tag)
+    except Exception:
+        # If resolve_repository_name fails, just use the raw value
+        image = tag
+        registry = None
+
+    # HACK: Strip "library" from official images
+    if registry == docker.auth.INDEX_NAME:
+        image = image.removeprefix("library/")
+
+    image_only = image.split(":", 1)[0]
+    return image_only
 
 @pycron.cron(SCHEDULE)
 def backup(now: datetime) -> None:


### PR DESCRIPTION
- Add support for images missing the container.image.tags due to being pulled by digest
- Add the new name for the nextcloud-aio psql db (keeping the old name in case someone wants to use this with older versions)

Closes #101 